### PR TITLE
Handle both jpg and gif files

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -838,7 +838,16 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     // create temp file
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-    filePath = [filePath stringByAppendingString:@".jpg"];
+    NSString *mimeType = [self determineMimeTypeFromImageData:data];
+    if([mimeType isEqualToString:@"image/jpeg"]){
+        filePath = [filePath stringByAppendingString:@".jpg"];
+    }
+    else if([mimeType isEqualToString:@"image/gif"]){
+        filePath = [filePath stringByAppendingString:@".gif"];
+    }
+    else {
+        filePath = [filePath stringByAppendingString:@".jpg"];
+    }
 
     // save cropped file
     BOOL status = [data writeToFile:filePath atomically:YES];


### PR DESCRIPTION
This change is from ivpusic/react-native-image-crop-picker#1301 and copied into here because this it hasn't been merged and released in the upstream repo.

My strategy for fixing this issue is a straightforward copy and paste of the implementation in the original PR.